### PR TITLE
Docu build cmake option

### DIFF
--- a/ddsenabler_docs/docs/ddsenabler/installation/cmake_options.rst
+++ b/ddsenabler_docs/docs/ddsenabler/installation/cmake_options.rst
@@ -14,6 +14,10 @@ These options allow the developer to enable/disable certain *eProsima DDS Enable
 .. warning::
     These options are only for developers who installed *eProsima DDS Enabler* following the compilation steps described in :ref:`installation_sources_linux`.
 
+***************
+General Options
+***************
+
 .. list-table::
     :header-rows: 1
 
@@ -26,11 +30,6 @@ These options allow the developer to enable/disable certain *eProsima DDS Enable
         - ``Release`` |br|
           ``Debug``
         - ``Release``
-    *   - :class:`BUILD_DOCS`
-        - Build the *eProsima DDS Enabler* |br| documentation. |br|
-        - ``OFF`` |br|
-          ``ON``
-        - ``OFF``
     *   - :class:`BUILD_TESTS`
         - Build the *eProsima DDS Enabler* tools and |br| documentation tests.
         - ``OFF`` |br|
@@ -59,3 +58,27 @@ These options allow the developer to enable/disable certain *eProsima DDS Enable
         - ``OFF`` |br|
           ``ON``
         - ``OFF``
+
+
+**************************
+Documentation Build Option
+**************************
+
+.. important::
+    The following option is only relevant for building the local documentation project (`ddsenabler_docs`):
+
+.. list-table::
+    :header-rows: 1
+
+    *   - Option
+        - Description
+        - Possible values
+        - Default
+    *   - :class:`BUILD_DOCS`
+        - Build the *eProsima DDS Enabler* |br| documentation. |br|
+        - ``OFF`` |br|
+          ``ON``
+        - ``OFF``
+
+.. note::
+    Once built, the generated HTML documentation is located under ``build/ddsenabler_docs/html``


### PR DESCRIPTION
Separate the docs project and its specific cmake option in the documentation.